### PR TITLE
Update BYD link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Build & Modernize AI Applications
 
-This page is intended as a home page for all of the Microsoft Official Build & Modernize AI Applications reference solutions and content. The projects listed below provide access to the published Microsoft content on how to build AI-enabled applications using Azure OpenAI Service, Azure Container Apps (or Azure Kuberntes Service), Azure Cosmos DB and Azure Cognitive Search.
+This page is intended as a home page for all of the Microsoft Official Build & Modernize AI Applications reference solutions and content. The projects listed below provide access to the published Microsoft content on how to build AI-enabled applications using Azure OpenAI Service, Azure Container Apps (or Azure Kubernetes Service), and Azure Cosmos DB.
 
 ## Solutions
 


### PR DESCRIPTION
The Vector Search & AI Assistant solution accelerator should now point to `main` instead of the vector search branch.